### PR TITLE
test chronometer with predefined clock to reduce test duration and in…

### DIFF
--- a/src/test/scala/com/truelaurel/codingame/time/ChronometerTest.scala
+++ b/src/test/scala/com/truelaurel/codingame/time/ChronometerTest.scala
@@ -1,7 +1,10 @@
 package com.truelaurel.codingame.time
 
-import scala.concurrent.duration.Duration
+import java.util.concurrent.TimeUnit
+
 import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration.Duration
 
 /**
   * Created by Wei on 14/06/2017.
@@ -10,17 +13,41 @@ class ChronometerTest extends FlatSpec with Matchers {
 
   behavior of "Chronometer"
 
-  val millis = 1000
-  val duration = Duration(millis, "millis")
-  val cs = new Chronometer(duration)
-  cs.start()
+  val duration = Duration(1, TimeUnit.SECONDS)
 
   it should "return false while counter still alive" in {
+    val cs = new Chronometer(duration) {
+
+      var predefinedClock = new PredefinedClock(Vector(0, duration.toNanos / 2))
+
+      override def mark: Long = {
+        predefinedClock.tick()
+      }
+    }
+    cs.start()
     cs.willOutOfTime should equal(false)
   }
 
   it should "return true after counter ran out" in {
-    Thread.sleep(millis)
+    val cs = new Chronometer(duration) {
+
+      var predefinedClock = new PredefinedClock(Vector(0, duration.toNanos * 2))
+
+      override def mark: Long = {
+        predefinedClock.tick()
+      }
+    }
+    cs.start()
     cs.willOutOfTime should equal(true)
+  }
+}
+
+class PredefinedClock(values: Vector[Long]) {
+  private var i = -1
+
+  def tick(): Long = {
+    i += 1
+    require(i < values.size, "All predefined values are consumed")
+    values(i)
   }
 }


### PR DESCRIPTION
…crease test certainty

random failure detected in the CI
https://travis-ci.org/TrueLaurel/CodinGame-Scala-Kit/builds/243974053